### PR TITLE
feat: Add Jupyter notebook framework and streamline question flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Educational formula explanations in the UI
 - Clear error messages and user guidance
 
+## [1.1.0] - 2025-01-14
+
+### Added
+- **Jupyter Notebook Framework**: Downloadable template notebook for offline calculation work
+- **Enhanced Question Flow**: Streamlined from 7 to 6 questions focusing on practical calculations
+- **Business Impact Focus**: New Question 6 for calculating additional conversions per day
+- **Improved Navigation**: Fixed question numbering inconsistencies and navigation logic
+- **Offline Learning**: Complete framework for working through design questions outside the web app
+
+### Changed
+- **Question Flow Optimization**: Removed theoretical power analysis question (Question 7) for more practical focus
+- **Enhanced UI**: Added notebook download section in design step with clear instructions
+- **Question Numbering**: Fixed inconsistencies between navigation (5 vs 7 questions) to consistent 6 questions
+- **Scoring Logic**: Updated to handle 6 questions instead of 7 with proper validation
+
+### Improved
+- **User Experience**: More focused learning path from statistical design to business impact
+- **Educational Value**: Framework notebook provides structured approach to calculations
+- **Interview Preparation**: Emphasizes most valuable skills for A/B testing interviews
+- **Time Efficiency**: Streamlined flow gets users to data analysis faster
+
+### Technical Improvements
+- **Template System**: Created reusable Jupyter notebook template with placeholders
+- **Download Integration**: Seamless notebook download with timestamped filenames
+- **Error Handling**: Robust file handling for notebook template delivery
+- **Code Organization**: Clean separation of concerns between web app and offline framework
+
 ## [Unreleased]
 
 ### Planned

--- a/llm/client.py
+++ b/llm/client.py
@@ -238,11 +238,12 @@ class LLMClient:
                   },
                   "design_params": {
                     "baseline_conversion_rate": 0.025,
+                    "mde_absolute": 0.005,
                     "target_lift_pct": 0.20,
-                    "alpha": 0.05,
-                    "power": 0.8,
+                    "alpha": 0.01,
+                    "power": 0.90,
                     "allocation": {"control": 0.5, "treatment": 0.5},
-                    "expected_daily_traffic": 25000
+                    "expected_daily_traffic": 2500
                   },
                   "llm_expected": {
                     "simulation_hints": {
@@ -299,11 +300,12 @@ class MockLLMClient:
   },
   "design_params": {
     "baseline_conversion_rate": 0.025,
+    "mde_absolute": 0.005,
     "target_lift_pct": 0.20,
-    "alpha": 0.05,
-    "power": 0.8,
+    "alpha": 0.10,
+    "power": 0.70,
     "allocation": {"control": 0.5, "treatment": 0.5},
-    "expected_daily_traffic": 10000
+    "expected_daily_traffic": 1800
   },
   "llm_expected": {
     "simulation_hints": {

--- a/llm/generator.py
+++ b/llm/generator.py
@@ -86,11 +86,12 @@ class LLMScenarioGenerator:
   },
   "design_params": {
     "baseline_conversion_rate": 0.025,
+    "mde_absolute": 0.005,
     "target_lift_pct": 0.20,
-    "alpha": 0.05,
-    "power": 0.8,
+    "alpha": 0.01,
+    "power": 0.95,
     "allocation": {"control": 0.5, "treatment": 0.5},
-    "expected_daily_traffic": 10000
+    "expected_daily_traffic": 3200
   },
   "llm_expected": {
     "simulation_hints": {

--- a/llm/parser.py
+++ b/llm/parser.py
@@ -354,11 +354,12 @@ class LLMOutputParser:
             },
             "design_params": {
                 "baseline_conversion_rate": 0.025,
+                "mde_absolute": 0.005,
                 "target_lift_pct": 0.20,
-                "alpha": 0.05,
-                "power": 0.8,
+                "alpha": 0.10,
+                "power": 0.70,
                 "allocation": {"control": 0.5, "treatment": 0.5},
-                "expected_daily_traffic": 10000
+                "expected_daily_traffic": 1500
             },
             "llm_expected": {
                 "simulation_hints": {

--- a/llm/prompts/scenario_prompt.txt
+++ b/llm/prompts/scenario_prompt.txt
@@ -37,7 +37,7 @@ You MUST return ONLY valid JSON in this exact structure:
 {
   "scenario": {
     "title": "Brief, descriptive title with company name",
-    "narrative": "Detailed, interview-style scenario description (4-6 sentences) including: company background, current situation with specific baseline metrics (e.g., 'currently converting at 3.2%'), specific changes being tested, and business context. End with a business goal that defines the MDE in absolute terms (e.g., 'The business believes that if it can increase the CTR by around 3 percentage points, the effort to make the change would be worth the unlock'). Make it feel like a real company asking for help with an experiment.",
+    "narrative": "Detailed, interview-style scenario description (4-6 sentences) including: company background, current situation with specific baseline metrics (e.g., 'currently converting at 3.2%'), specific changes being tested, and business context. End with a business goal that defines the MDE as a raw ratio increase (e.g., 'The business believes that if it can increase the CTR by around 0.03 (3 percentage points), the effort to make the change would be worth the unlock'). CRITICAL: The MDE must always be expressed as a raw ratio increase (0.001 to 0.1), not as absolute time, revenue, or other continuous metrics. Make it feel like a real company asking for help with an experiment.",
     "company_type": "SaaS",
     "user_segment": "all_users", 
     "primary_kpi": "conversion_rate",
@@ -49,8 +49,8 @@ You MUST return ONLY valid JSON in this exact structure:
     "baseline_conversion_rate": 0.18,
     "mde_absolute": 0.03,
     "target_lift_pct": 0.167,
-    "alpha": 0.05,
-    "power": 0.8,
+    "alpha": 0.01,
+    "power": 0.90,
     "allocation": {"control": 0.5, "treatment": 0.5},
     "expected_daily_traffic": 15000
   },
@@ -88,10 +88,12 @@ You MUST return ONLY valid JSON in this exact structure:
 - "all_users"
 
 ### Primary KPIs (choose one):
-- "conversion_rate"
-- "click_through_rate"
-- "revenue_per_user"
-- "engagement_rate"
+- "conversion_rate" - proportion of users who complete an action (e.g., signup, purchase, download)
+- "click_through_rate" - proportion of users who click on a specific element (e.g., button, link, CTA)
+- "revenue_per_user" - proportion of users who generate revenue (e.g., make a purchase, subscribe)
+- "engagement_rate" - proportion of users who meet engagement criteria (e.g., spend 15+ minutes, view 3+ pages)
+
+**IMPORTANT**: All KPIs must be measurable as proportions/percentages, not as continuous metrics like time duration, absolute revenue amounts, or session counts.
 
 ### Units (choose one):
 - "visitor"
@@ -103,11 +105,42 @@ You MUST return ONLY valid JSON in this exact structure:
 
 ### Design Parameters
 - **baseline_conversion_rate**: 0.001 to 0.5 (0.1% to 50%)
+- **mde_absolute**: 0.001 to 0.1 (raw ratio increase, equivalent to 0.1% to 10% percentage points) - MUST be a raw ratio, not absolute time/revenue
 - **target_lift_pct**: -0.5 to 0.5 (-50% to +50%)
 - **alpha**: 0.01 to 0.1 (1% to 10%)
 - **power**: 0.7 to 0.95 (70% to 95%)
 - **allocation**: Must sum to 1.0, both values between 0 and 1
 - **expected_daily_traffic**: 500 to 5,000
+
+**CRITICAL MDE CONSTRAINT**: The mde_absolute must always be a raw ratio between 0.001 and 0.1 (e.g., 0.03 = 3 percentage points), never absolute values like "3 minutes", "$50 revenue", or "2 sessions". The narrative must frame the business goal with the raw ratio value.
+
+**MATHEMATICAL CONSISTENCY REQUIREMENT**: The mde_absolute and target_lift_pct must be mathematically consistent:
+- mde_absolute = baseline_conversion_rate × target_lift_pct
+- target_lift_pct = mde_absolute ÷ baseline_conversion_rate
+- Example: baseline=0.18, mde_absolute=0.03, then target_lift_pct=0.03÷0.18=0.167
+
+### Statistical Parameters (Choose Based on Business Context)
+
+**Alpha (Significance Level) - Choose based on business risk tolerance:**
+- **0.01 (1%)**: High-stakes decisions, regulatory compliance, safety-critical changes, financial services
+- **0.05 (5%)**: Standard business decisions, most A/B tests, typical product optimization
+- **0.10 (10%)**: Exploratory tests, low-risk experiments, early-stage startups, resource-constrained teams
+
+**Power (Statistical Power) - Choose based on business importance and resources:**
+- **0.70 (70%)**: Exploratory tests, limited resources, early-stage validation, low-cost experiments
+- **0.80 (80%)**: Standard business experiments, most product optimization tests
+- **0.90 (90%)**: High-stakes decisions, regulatory requirements, major feature launches
+- **0.95 (95%)**: Critical business decisions, safety testing, compliance requirements
+
+**Choose alpha and power based on:**
+- **Business risk tolerance**: Higher stakes = lower alpha, higher power
+- **Cost of false positives vs false negatives**: Balance Type I and Type II errors
+- **Resource constraints**: Higher power requires larger sample sizes
+- **Regulatory requirements**: Some industries require specific thresholds
+- **Decision importance**: Critical decisions need higher power and lower alpha
+- **Company stage**: Startups may use higher alpha/lower power for speed
+
+**Vary these parameters realistically** - don't always use 0.05 for alpha and 0.8 for power. Consider the business context when choosing values.
 
 **IMPORTANT**: Generate realistic, varied daily traffic numbers between 500 and 5,000 daily visitors:
 - **Small startups**: 500 - 1,500 daily visitors
@@ -179,6 +212,16 @@ Generate scenarios for these business contexts:
 
 ### Good Scenario Example (Single Intervention)
 **Title**: "ShopFast Checkout Button Color Test"
+
+**CORRECT MDE Examples** (raw ratio increases):
+- "increase conversion rate by 0.02 (2 percentage points)" (mde_absolute: 0.02)
+- "boost click-through rate by 0.035 (3.5 percentage points)" (mde_absolute: 0.035)
+- "improve engagement rate by 0.018 (1.8 percentage points)" (mde_absolute: 0.018)
+
+**INCORRECT MDE Examples** (continuous metrics - DO NOT USE):
+- "increase session duration by 3 minutes" ❌
+- "boost revenue by $50 per user" ❌
+- "improve page views by 2 sessions" ❌
 **Narrative**: "ShopFast is a fast-growing e-commerce platform specializing in electronics and home goods, currently processing 50,000 orders per month with a checkout conversion rate of 12.5%. The product team has identified that 68% of users abandon their carts during the checkout process, with the majority dropping off at the final 'Complete Purchase' step. After user research, they've discovered that the current blue checkout button may not be prominent enough to drive action. They want to test changing ONLY the checkout button color from blue to green, keeping everything else identical (same text, same size, same position, same page layout). The hypothesis is that a green button will create a stronger call-to-action and increase checkout completion rates. The business believes that if it can increase the checkout conversion rate by around 2 percentage points, the effort to make the change would be worth the unlock."
 
 ### Bad Scenario Example (Multiple Interventions)

--- a/notebooks/ab_test_design_template.ipynb
+++ b/notebooks/ab_test_design_template.ipynb
@@ -1,0 +1,183 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# A/B Test Design Framework\n",
+        "\n",
+        "This notebook provides a framework for working through the experiment design questions.\n",
+        "Fill in the values from your scenario and work through each calculation step.\n",
+        "\n",
+        "## Scenario Parameters\n",
+        "Extract these values from the scenario narrative:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Question 1: Business's targeted MDE (from scenario narrative)\n",
+        "mde_absolute = None  # Fill in: MDE in absolute terms (e.g., 0.03 for 3 percentage points)\n",
+        "mde_percentage_points = None  # Fill in: MDE in percentage points (e.g., 3.0)\n",
+        "\n",
+        "print(f\"MDE (absolute): {mde_absolute}\")\n",
+        "print(f\"MDE (percentage points): {mde_percentage_points}%\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Question 2: Target conversion rate calculation\n",
+        "baseline_conversion_rate = None  # Fill in: Baseline rate from scenario (e.g., 0.15 for 15%)\n",
+        "target_conversion_rate = None  # Calculate: baseline + mde_absolute\n",
+        "\n",
+        "# Your calculation here:\n",
+        "# target_conversion_rate = baseline_conversion_rate + mde_absolute\n",
+        "\n",
+        "print(f\"Baseline conversion rate: {baseline_conversion_rate:.1%}\")\n",
+        "print(f\"Target conversion rate: {target_conversion_rate:.1%}\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Question 3: Relative lift calculation\n",
+        "relative_lift_pct = None  # Calculate: (mde_absolute / baseline_conversion_rate) * 100\n",
+        "\n",
+        "# Your calculation here:\n",
+        "# relative_lift_pct = (mde_absolute / baseline_conversion_rate) * 100\n",
+        "\n",
+        "print(f\"Relative lift: {relative_lift_pct:.1f}%\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Sample Size Calculation\n",
+        "\n",
+        "Use the two-proportion z-test formula:\n",
+        "\n",
+        "```\n",
+        "n = (z_α/2 + z_β)² × [p₁(1-p₁) + p₂(1-p₂)] / (p₂ - p₁)²\n",
+        "```\n",
+        "\n",
+        "Where:\n",
+        "- `z_α/2` = Critical value for two-tailed test\n",
+        "- `z_β` = Critical value for power (one-tailed)\n",
+        "- `p₁` = Baseline conversion rate\n",
+        "- `p₂` = Treatment conversion rate = p₁ × (1 + lift%)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Question 4: Sample size calculation\n",
+        "alpha = None  # Fill in: Significance level from scenario (e.g., 0.05)\n",
+        "power = None  # Fill in: Statistical power from scenario (e.g., 0.8)\n",
+        "\n",
+        "# Critical z-values (look these up in z-tables or use statistical software)\n",
+        "z_alpha_over_2 = None  # Fill in: Critical z-value for α/2 (e.g., 1.96 for α=0.05)\n",
+        "z_beta = None  # Fill in: Critical z-value for power (e.g., 0.841621 for 80% power)\n",
+        "\n",
+        "# Conversion rates\n",
+        "p1 = baseline_conversion_rate  # Baseline rate\n",
+        "p2 = None  # Calculate: p1 * (1 + relative_lift_pct/100)\n",
+        "\n",
+        "# Your calculations here:\n",
+        "# p2 = p1 * (1 + relative_lift_pct/100)\n",
+        "# n = ((z_alpha_over_2 + z_beta)**2 * (p1*(1-p1) + p2*(1-p2))) / ((p2 - p1)**2)\n",
+        "n = None  # Fill in: Your calculated sample size per group\n",
+        "\n",
+        "print(f\"Alpha: {alpha}\")\n",
+        "print(f\"Power: {power:.1%}\")\n",
+        "print(f\"z_α/2: {z_alpha_over_2}\")\n",
+        "print(f\"z_β: {z_beta}\")\n",
+        "print(f\"p1 (baseline): {p1:.3f}\")\n",
+        "print(f\"p2 (treatment): {p2:.3f}\")\n",
+        "print(f\"Sample size per group: {n:,.0f}\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Question 5: Experiment duration\n",
+        "daily_traffic = None  # Fill in: Expected daily traffic from scenario\n",
+        "total_sample_size = None  # Calculate: n * 2 (both groups)\n",
+        "duration_days = None  # Calculate: total_sample_size / daily_traffic\n",
+        "\n",
+        "# Your calculations here:\n",
+        "# total_sample_size = n * 2\n",
+        "# duration_days = total_sample_size / daily_traffic\n",
+        "\n",
+        "print(f\"Daily traffic: {daily_traffic:,}\")\n",
+        "print(f\"Total sample size: {total_sample_size:,}\")\n",
+        "print(f\"Duration: {duration_days:.1f} days\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Question 6: Business impact calculation\n",
+        "additional_conversions_per_day = None  # Calculate: daily_traffic * mde_absolute\n",
+        "\n",
+        "# Your calculation here:\n",
+        "# additional_conversions_per_day = daily_traffic * mde_absolute\n",
+        "\n",
+        "print(f\"Additional conversions per day: {additional_conversions_per_day:,.0f}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Summary\n",
+        "\n",
+        "Your experiment design:\n",
+        "- **MDE**: [Your answer] percentage points\n",
+        "- **Target conversion rate**: [Your answer]%\n",
+        "- **Relative lift**: [Your answer]%\n",
+        "- **Sample size per group**: [Your answer] users\n",
+        "- **Experiment duration**: [Your answer] days\n",
+        "- **Business impact**: [Your answer] additional conversions per day\n",
+        "\n",
+        "## Resources\n",
+        "- [Evan Miller's Sample Size Calculator](https://www.evanmiller.org/ab-testing/sample-size.html)\n",
+        "- [Z-table for critical values](https://www.z-table.com/)\n",
+        "- [Statistical Power Calculator](https://www.stat.ubc.ca/~rollin/stats/ssize/b2.html)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
- Add downloadable Jupyter notebook template for offline calculation work
- Streamline question flow from 7 to 6 questions focusing on practical calculations
- Remove theoretical power analysis question for more practical focus
- Add business impact calculation question (additional conversions per day)
- Fix question numbering inconsistencies and navigation logic
- Update scoring logic to handle 6 questions instead of 7
- Enhance UI with notebook download section in design step
- Improve user experience with focused learning path from design to business impact
- Add comprehensive template with placeholders and educational resources

This release emphasizes the most valuable skills for A/B testing interviews and provides both interactive web app and offline framework options.