### PR TITLE
v1.2.0: Add Question 7 rollout decision and architectural refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Error Handling**: Robust file handling for notebook template delivery
 - **Code Organization**: Clean separation of concerns between web app and offline framework
 
+## [1.2.0] - 2025-01-15
+
+### Added
+- **Question 7 - Rollout Decision**: New analysis question for interpreting confidence intervals vs business targets
+- **`make_rollout_decision()` Function**: CI-based go/no-go decision logic with three outcomes
+- **Enhanced Analysis Section**: Complete rebuild with 7 progressive questions
+- **Core Validation Module**: Centralized answer validation and scoring system
+- **Core Scoring Module**: Answer key generation and comprehensive quiz result management
+- **Analysis Notebook Template**: Downloadable Jupyter notebook with all 7 analysis questions
+- **Business Target Integration**: LLM scenario business targets used for rollout decisions
+- **Progressive Question Display**: Analysis questions appear one by one like design section
+
+### Changed
+- **Architecture Refactoring**: Moved statistical calculations, validation, and scoring from UI to core modules
+- **Analysis Question Flow**: Rebuilt from scratch with proper progressive display
+- **Question Count**: Analysis section expanded from 6 to 7 questions
+- **Validation System**: Centralized validation logic in `core/validation.py`
+- **Scoring System**: Centralized scoring logic in `core/scoring.py`
+- **UI Simplification**: UI layer now focuses on question flow and user interaction
+- **Data Download Page**: Renovated with loading animation and improved messaging
+
+### Improved
+- **Separation of Concerns**: Clear `llm -> core -> ui` architecture
+- **Code Maintainability**: Eliminated duplicated statistical calculations
+- **Educational Value**: Complete analysis workflow from data to business decision
+- **User Experience**: Consistent question flow between design and analysis sections
+- **Statistical Accuracy**: Fixed p-value validation bug with duplicate dictionary keys
+- **Business Decision Making**: Realistic rollout recommendations based on CI vs targets
+
+### Technical Improvements
+- **Core Module Enhancement**: Added `make_rollout_decision()` to `core/analyze.py`
+- **Validation Updates**: Support for 7 analysis questions with business target integration
+- **Scoring Updates**: Proper handling of rollout decision validation with exact match
+- **Notebook Templates**: Updated analysis notebook with Question 7 decision logic
+- **Error Handling**: Fixed validation issues and improved error messages
+- **Type Safety**: Enhanced type hints and validation throughout core modules
+
+### Fixed
+- **P-value Validation Bug**: Fixed duplicate dictionary key issue in scoring
+- **Question Numbering**: Consistent numbering across all sections
+- **Navigation Logic**: Proper bounds checking for question navigation
+- **Validation Tolerances**: Appropriate tolerances for different question types
+- **Business Target Integration**: Proper use of LLM scenario business targets
+
+### Documentation
+- **Core README**: Comprehensive update documenting all new modules and functions
+- **Function Status**: Clear documentation of which functions are used vs available
+- **Usage Examples**: Updated examples showing new validation and scoring workflows
+- **Architecture Documentation**: Clear explanation of separation of concerns
+
 ## [Unreleased]
 
 ### Planned

--- a/core/README.md
+++ b/core/README.md
@@ -10,6 +10,7 @@ The core module provides:
 - **Domain types** for mathematical concepts only
 - **Statistical analysis** with multiple test options
 - **Business impact calculations** based on mathematical results
+- **Realistic data simulation** with treatment effect uncertainty
 
 ## Architecture Principles
 
@@ -18,11 +19,12 @@ The core module provides:
 - **Immutable Types**: All dataclasses are frozen for data integrity
 - **Mathematical Focus**: Only mathematical domain logic, no business context
 - **Testable**: 100% branch coverage on mathematical functions
+- **Reproducible**: Fixed seeds ensure consistent simulation results
 
 ## Module Contents
 
-### `types.py` - Core Domain Types
-Pure mathematical domain objects:
+### `__init__.py` - Module Exports
+Public API exports for the core module:
 
 - **`Allocation`**: Traffic allocation between control/treatment groups
 - **`DesignParams`**: Core statistical parameters (baseline, lift, alpha, power, traffic)
@@ -31,46 +33,204 @@ Pure mathematical domain objects:
 - **`AnalysisResult`**: Statistical analysis results (p-value, CI, significance)
 - **`BusinessImpact`**: Mathematical business impact calculations
 - **`TestQuality`**: Mathematical test quality indicators
+- **`ValidationResult`**: Answer validation results with feedback
+- **`ScoringResult`**: Quiz scoring results with grades
+- **`AnswerKey`**: Answer keys for quiz questions
+- **`QuizResult`**: Complete quiz results with scoring and feedback
+
+### `types.py` - Core Domain Types
+Pure mathematical domain objects with validation:
+
+- **`Allocation`**: Traffic allocation between control/treatment groups
+  - Validates proportions sum to 1.0
+  - Properties: `control`, `treatment`, `total`
+- **`DesignParams`**: Core statistical parameters
+  - Fields: `baseline_conversion_rate`, `target_lift_pct`, `alpha`, `power`, `allocation`, `expected_daily_traffic`
+  - Validates parameter ranges and constraints
+- **`SampleSize`**: Sample size calculation results
+  - Fields: `per_arm`, `total`, `days_required`, `power_achieved`
+  - Validates mathematical consistency
+- **`SimResult`**: Simulation results with conversion counts
+  - Fields: `control_n`, `control_conversions`, `treatment_n`, `treatment_conversions`, `user_data`
+  - Properties: `control_rate`, `treatment_rate`, `absolute_lift`, `relative_lift_pct`
+- **`AnalysisResult`**: Statistical analysis results
+  - Fields: `test_statistic`, `p_value`, `confidence_interval`, `confidence_level`, `significant`, `effect_size`, `power_achieved`, `recommendation`
+- **`BusinessImpact`**: Mathematical business impact calculations
+  - Fields: `absolute_lift`, `relative_lift_pct`, `revenue_impact_monthly`, `confidence_in_revenue`, `rollout_recommendation`, `risk_level`, `implementation_complexity`
+- **`TestQuality`**: Mathematical test quality indicators
+  - Fields: `early_stopping_risk`, `novelty_effect_potential`, `seasonality_impact`, `traffic_consistency`, `allocation_balance`, `sample_size_adequacy`, `power_achieved`
 
 ### `design.py` - Sample Size Calculation
-Statistical design functions:
+Statistical design functions for AB test planning:
 
 - **`compute_sample_size()`**: Two-proportion z-test sample size calculation
+  - Uses standard formula: `n = (z_alpha + z_beta)^2 * [p1(1-p1) + p2(1-p2)] / (p2-p1)^2`
+  - Returns `SampleSize` with per-arm, total, days required, and achieved power
 - **`_get_z_score()`**: Z-score calculation for given alpha and direction
+  - Supports one-tailed and two-tailed tests
+  - Uses exact values for common alpha levels (0.01, 0.05, 0.10)
 - **`_calculate_achieved_power()`**: Power calculation for given sample size
+  - Calculates achieved power based on effect size and sample size
 - **`calculate_minimum_detectable_effect()`**: MDE calculation
+  - Calculates minimum detectable effect for given sample size and power
+- **`validate_test_duration()`**: Validate test duration against business constraints
+- **`suggest_parameter_adjustments()`**: Suggest parameter changes if constraints not met
+- **`_normal_cdf()`**: Normal cumulative distribution function approximation
 
 ### `simulate.py` - Data Simulation
-Deterministic data generation:
+Realistic data generation with treatment effect variation:
 
-- **`simulate_trial()`**: Generate realistic AB test data with seeded RNG
+- **`simulate_trial()`**: Generate realistic AB test data with seeded RNG and treatment effect uncertainty
+  - **Control rate variation**: ±10% variation around baseline to reflect sampling variability
+  - **Treatment effect variation**: 70% chance of achieving target lift, 20% partial success, 8% failure, 2% negative effect
+  - **Reproducible**: Fixed seeds ensure consistent results
+  - **Realistic outcomes**: Allows for both successful and unsuccessful experiments
 - **`_generate_user_data()`**: Create user-level data with timestamps
-- **Traffic splitting**: Based on allocation with realistic variation
-- **Reproducible**: Fixed seeds ensure consistent results
+  - Generates realistic user attributes: session duration, page views, device type, traffic source
+  - Uses Bernoulli trials for conversion simulation
+- **`_generate_realistic_timestamp()`**: Generate timestamps with business hour patterns
+- **`_generate_session_duration()`**: Generate session duration based on conversion status
+- **`_generate_page_views()`**: Generate page views based on conversion status
+- **`_generate_device_type()`**: Generate realistic device type distribution
+- **`_generate_traffic_source()`**: Generate realistic traffic source distribution
+- **`validate_simulation_consistency()`**: Validate simulated data against expected rates
+- **`add_seasonality_pattern()`**: Add seasonality effects (weekend, holiday)
+- **`export_user_data_csv()`**: Export user-level data to CSV
+- **`get_aggregate_summary()`**: Generate aggregate summary statistics
 
 ### `analyze.py` - Statistical Analysis
-Comprehensive statistical testing:
+Comprehensive statistical testing and analysis:
 
 - **`analyze_results()`**: Main analysis function with multiple test options
+  - Supports: `two_proportion_z`, `chi_square`, `fisher_exact`
+  - Returns `AnalysisResult` with test statistics, p-value, CI, and recommendation
 - **`_two_proportion_z_test()`**: Two-proportion z-test implementation
+  - Calculates z-statistic, p-value, confidence interval, effect size, achieved power
 - **`_chi_square_test()`**: Chi-square test for categorical data
+  - Creates 2x2 contingency table, calculates chi-square statistic
 - **`_fisher_exact_test()`**: Fisher's exact test for small samples
-- **Confidence intervals**: For effect sizes and relative lift
-- **Power analysis**: Achieved power calculations
+  - Uses hypergeometric distribution approximation
+- **`_calculate_p_value()`**: P-value calculation for z-statistic
+- **`_calculate_confidence_interval()`**: Confidence interval for difference in proportions
+- **`_calculate_effect_size()`**: Cohen's h effect size calculation
+- **`_calculate_achieved_power()`**: Achieved power calculation
+- **`_generate_recommendation()`**: Business recommendation based on statistical results
+- **`make_rollout_decision()`**: Rollout decision based on confidence interval vs business target
+- **`calculate_business_impact()`**: Business impact calculations and projections
+- **`assess_test_quality()`**: Test quality indicators and potential issues
+- **`_normal_cdf()`**: Normal cumulative distribution function
+- **`_chi_square_p_value()`**: Chi-square p-value approximation
+- **`_fisher_exact_p_value()`**: Fisher's exact p-value approximation
 
 ### `rng.py` - Random Number Generation
-Centralized PRNG factory:
+Centralized PRNG factory for reproducible simulations:
 
+- **`RNGFactory`**: Factory class for creating reproducible random number generators
+  - Component-based seeding for deterministic but varied results
+  - Thread-safe generator management
 - **`get_rng()`**: Get seeded numpy Generator for reproducibility
-- **Consistent seeding**: Same seed produces same results across modules
-- **Thread-safe**: Each call gets independent generator
+- **`set_global_seed()`**: Set global seed for all random number generation
+- **`reset_rng()`**: Reset all random number generators
+- **`get_rng_state()`**: Get current state of all generators
+- **`set_rng_state()`**: Restore state of all generators
+- **Distribution generators**:
+  - `generate_bernoulli_samples()`: Bernoulli trials
+  - `generate_uniform_samples()`: Uniform distribution
+  - `generate_normal_samples()`: Normal distribution
+  - `generate_choice_samples()`: Random choices
+  - `generate_weighted_choice_samples()`: Weighted random choices
+  - `generate_poisson_samples()`: Poisson distribution
+  - `generate_exponential_samples()`: Exponential distribution
+  - `generate_beta_samples()`: Beta distribution
+  - `generate_gamma_samples()`: Gamma distribution
+  - `generate_multinomial_samples()`: Multinomial distribution
+  - `generate_correlated_samples()`: Multivariate normal
+  - `generate_time_series_samples()`: Time series with trend/seasonality
+  - `generate_mixture_samples()`: Mixture distributions
+
+### `validation.py` - Answer Validation and Scoring
+Validation and scoring logic for quiz answers:
+
+- **`validate_design_answer()`**: Validate individual design question answers
+  - Supports all 6 design questions (MDE, target rate, relative lift, sample size, duration, additional conversions)
+  - Uses scenario's `mde_absolute` when provided, falls back to calculated value
+  - Returns `ValidationResult` with correctness, feedback, and tolerance
+- **`validate_analysis_answer()`**: Validate individual analysis question answers
+  - Supports all 7 analysis questions (control rate, treatment rate, absolute lift, relative lift, p-value, confidence interval, rollout decision)
+  - Uses `SimResult` properties and `AnalysisResult` from statistical analysis
+  - Returns `ValidationResult` with correctness, feedback, and tolerance
+- **`calculate_correct_design_answers()`**: Calculate correct answers for all design questions
+  - Uses scenario's `mde_absolute` when provided
+  - Returns dictionary with all correct answers
+- **`calculate_correct_analysis_answers()`**: Calculate correct answers for all analysis questions
+  - Uses `SimResult` properties and runs statistical analysis
+  - Includes rollout decision calculation using `make_rollout_decision`
+  - Returns dictionary with all correct answers
+- **`score_design_answers()`**: Score complete design quiz
+  - Compares user answers against correct answers with tolerances
+  - Returns `ScoringResult` with scores, percentage, and grade
+- **`score_analysis_answers()`**: Score complete analysis quiz
+  - Compares user answers against correct answers with tolerances
+  - Supports 7 analysis questions including rollout decision
+  - Returns `ScoringResult` with scores, percentage, and grade
+
+### `scoring.py` - Answer Key Generation and Quiz Results
+Answer key generation and comprehensive quiz result management:
+
+- **`generate_design_answer_key()`**: Generate answer key for design questions
+  - Creates `AnswerKey` with questions, hints, types, and correct answers
+  - Includes all 6 design questions with proper formatting
+- **`generate_analysis_answer_key()`**: Generate answer key for analysis questions
+  - Creates `AnswerKey` with questions, hints, types, and correct answers
+  - Includes all 7 analysis questions with proper formatting
+- **`generate_quiz_feedback()`**: Generate detailed feedback for quiz results
+  - Creates comprehensive feedback with question-by-question results
+  - Includes overall score, grade, and individual question feedback
+- **`create_complete_quiz_result()`**: Create complete quiz result
+  - Combines answer key, scoring results, user answers, and feedback
+  - Returns `QuizResult` with all quiz information
+- **`export_answer_key_to_csv()`**: Export answer key to CSV file
+- **`export_quiz_results_to_csv()`**: Export quiz results to CSV file
+- **`_get_question_key()`**: Helper function to get question keys by number and type
 
 ### `utils.py` - Mathematical Utilities
-Helper functions for calculations:
+Helper functions for calculations and formatting:
 
-- **`calculate_relative_lift()`**: Convert absolute to relative lift
-- **`calculate_absolute_lift()`**: Convert relative to absolute lift
-- **Business impact helpers**: Revenue calculations and projections
+- **Lift calculations**:
+  - `relative_lift_to_absolute()`: Convert relative lift percentage to absolute difference
+  - `absolute_lift_to_relative()`: Convert absolute difference to relative lift percentage
+- **Revenue impact**:
+  - `calculate_revenue_impact()`: Revenue impact from conversion rate improvement
+  - `calculate_monthly_revenue_impact()`: Monthly revenue impact calculation
+  - `calculate_confidence_interval_for_revenue()`: Revenue confidence intervals
+  - `calculate_sample_size_for_revenue_detection()`: Sample size for revenue detection
+- **Effect size calculations**:
+  - `calculate_effect_size_cohens_h()`: Cohen's h for proportions
+  - `interpret_effect_size_cohens_h()`: Interpret Cohen's h effect size
+  - `calculate_effect_size_cohens_d()`: Cohen's d for means
+  - `interpret_effect_size_cohens_d()`: Interpret Cohen's d effect size
+- **Confidence intervals**:
+  - `calculate_confidence_interval_for_proportion()`: CI for single proportion
+  - `calculate_confidence_interval_for_difference()`: CI for difference in proportions
+  - `calculate_conversion_rate_confidence_interval()`: CI for conversion rate
+  - `calculate_relative_lift_confidence_interval()`: CI for relative lift
+- **Power and sample size**:
+  - `calculate_power_for_proportions()`: Statistical power for proportions
+  - `calculate_minimum_detectable_effect()`: MDE calculation
+  - `calculate_required_sample_size_for_power()`: Sample size for given power
+- **Formatting utilities**:
+  - `format_percentage()`: Format decimal as percentage string
+  - `format_currency()`: Format number as currency
+  - `format_large_number()`: Format large numbers with suffixes
+- **Validation utilities**:
+  - `validate_conversion_rate()`: Validate conversion rate bounds
+  - `validate_sample_size()`: Validate sample size is positive
+  - `validate_confidence_level()`: Validate confidence level bounds
+  - `validate_significance_level()`: Validate significance level bounds
+  - `validate_power()`: Validate power level bounds
+- **Standard error calculations**:
+  - `calculate_conversion_rate_standard_error()`: Standard error for conversion rate
+- **`_normal_cdf()`**: Normal cumulative distribution function
 
 ## Usage Examples
 
@@ -97,10 +257,11 @@ print(f"Required: {sample_size.per_arm} per arm, {sample_size.days_required} day
 ```python
 from core.simulate import simulate_trial
 
-true_rates = {"control": 0.05, "treatment": 0.0575}
-sim_result = simulate_trial(params, true_rates, seed=42)
+# Core calculates true rates internally with realistic variation
+sim_result = simulate_trial(params, seed=42)
 print(f"Control: {sim_result.control_conversions}/{sim_result.control_n}")
 print(f"Treatment: {sim_result.treatment_conversions}/{sim_result.treatment_n}")
+print(f"Actual lift: {sim_result.relative_lift_pct:.1%}")
 ```
 
 ### Statistical Analysis
@@ -113,6 +274,86 @@ print(f"Significant: {analysis.significant}")
 print(f"Recommendation: {analysis.recommendation}")
 ```
 
+### Business Impact Analysis
+```python
+from core.analyze import calculate_business_impact, make_rollout_decision
+
+# Comprehensive business impact analysis
+business_impact = calculate_business_impact(
+    sim_result, 
+    revenue_per_conversion=50.0,
+    monthly_traffic=30000
+)
+print(f"Monthly revenue impact: ${business_impact.revenue_impact_monthly:,.2f}")
+print(f"Rollout recommendation: {business_impact.rollout_recommendation}")
+
+# Focused rollout decision based on CI vs business target
+rollout_decision = make_rollout_decision(
+    sim_result, 
+    analysis, 
+    business_target_absolute=0.03  # 3% absolute lift
+)
+print(f"Rollout decision: {rollout_decision}")
+```
+
+### Random Number Generation
+```python
+from core.rng import get_rng, generate_bernoulli_samples
+
+# Get component-specific RNG
+rng = get_rng("simulation")
+samples = generate_bernoulli_samples(rate=0.05, n=1000, rng_name="simulation")
+print(f"Generated {len(samples)} Bernoulli samples")
+```
+
+### Answer Validation and Scoring
+```python
+from core.validation import validate_design_answer, validate_analysis_answer, score_design_answers, score_analysis_answers
+from core.scoring import generate_design_answer_key, create_complete_quiz_result
+
+# Validate individual design question
+validation_result = validate_design_answer(
+    question_num=1, 
+    user_answer=1.0, 
+    design_params=params, 
+    sample_size_result=sample_size,
+    mde_absolute=0.01  # From LLM scenario
+)
+print(f"Correct: {validation_result.is_correct}, Feedback: {validation_result.feedback}")
+
+# Validate individual analysis question (including rollout decision)
+validation_result = validate_analysis_answer(
+    question_num=7, 
+    user_answer="proceed_with_confidence", 
+    sim_result=sim_result,
+    business_target_absolute=0.03
+)
+print(f"Correct: {validation_result.is_correct}, Feedback: {validation_result.feedback}")
+
+# Score complete design quiz
+user_answers = {"mde_absolute": 1.0, "target_conversion_rate": 6.0, ...}
+scoring_result = score_design_answers(user_answers, params, sample_size, mde_absolute=0.01)
+print(f"Score: {scoring_result.total_score}/{scoring_result.max_score} ({scoring_result.percentage:.1f}%)")
+
+# Score complete analysis quiz (7 questions including rollout decision)
+analysis_answers = {"control_conversion_rate": 25.0, "rollout_decision": "proceed_with_confidence", ...}
+scoring_result = score_analysis_answers(analysis_answers, sim_result, business_target_absolute=0.03)
+print(f"Score: {scoring_result.total_score}/{scoring_result.max_score} ({scoring_result.percentage:.1f}%)")
+
+# Generate answer key and complete quiz result
+answer_key = generate_design_answer_key(params, sample_size)
+quiz_result = create_complete_quiz_result(user_answers, design_params=params, sample_size_result=sample_size)
+```
+
+### Utility Functions
+```python
+from core.utils import relative_lift_to_absolute, format_percentage
+
+# Convert relative lift to absolute
+absolute_lift = relative_lift_to_absolute(control_rate=0.05, relative_lift_pct=20.0)
+print(f"Absolute lift: {format_percentage(absolute_lift)}")
+```
+
 ## Testing
 
 The core module has comprehensive test coverage:
@@ -121,6 +362,7 @@ The core module has comprehensive test coverage:
 - **Property tests**: Mathematical properties (monotonicity, boundary conditions)
 - **Edge cases**: Very small baselines, extreme lifts, boundary values
 - **Reproducibility**: Fixed seeds ensure consistent test results
+- **Validation tests**: Parameter validation and error handling
 
 Run tests with:
 ```bash
@@ -134,12 +376,13 @@ The core module is designed to be used by:
 
 - **`api/`**: FastAPI endpoints convert DTOs to core types
 - **`llm/`**: LLM outputs are validated and converted to core types
-- **`ui/`**: User interfaces display core calculation results
+- **`ui/`**: User interfaces display core calculation results and use core validation/scoring
 
 ## Data Flow
 
 ```
 API DTOs → Core Types → Mathematical Functions → Core Results → API DTOs
+LLM Scenarios → Core Validation → Core Scoring → UI Display
 ```
 
 The core module never directly handles:
@@ -148,6 +391,40 @@ The core module never directly handles:
 - Business context (company type, user segments)
 - LLM prompts or responses
 - File I/O operations
+- UI state management
+
+## Key Features
+
+### Realistic Simulation
+- **Control rate variation**: ±10% around baseline to reflect sampling variability
+- **Treatment effect uncertainty**: 70% success, 20% partial, 8% failure, 2% negative
+- **User-level data**: Realistic timestamps, session duration, device types, traffic sources
+- **Seasonality effects**: Weekend and holiday patterns
+
+### Statistical Rigor
+- **Multiple test types**: Two-proportion z-test, chi-square, Fisher's exact
+- **Effect size calculations**: Cohen's h and d
+- **Power analysis**: Achieved power calculations
+- **Confidence intervals**: For proportions, differences, and relative lift
+
+### Business Impact
+- **Revenue projections**: Monthly revenue impact calculations
+- **Risk assessment**: Rollout recommendations and risk levels
+- **Quality indicators**: Test quality assessment and potential issues
+- **Rollout decisions**: CI-based go/no-go decisions vs business targets
+
+### Answer Validation and Scoring
+- **Individual question validation**: Real-time feedback with tolerances
+- **Complete quiz scoring**: Comprehensive scoring with grades and feedback
+- **Answer key generation**: Automatic generation of correct answers
+- **Export capabilities**: CSV export for answer keys and quiz results
+- **MDE handling**: Uses LLM scenario's `mde_absolute` when available
+- **Rollout decision validation**: CI-based decision validation for Question 7
+
+### Reproducibility
+- **Fixed seeds**: Consistent results across runs
+- **Component-based RNG**: Deterministic but varied random number generation
+- **State management**: RNG state saving and restoration
 
 ## Future Extensions
 
@@ -156,5 +433,31 @@ The core module can be extended with:
 - **Sequential testing**: Group sequential boundaries
 - **Multiple metrics**: CUPED, variance reduction techniques
 - **Advanced power analysis**: Conditional power, futility analysis
+- **Bayesian methods**: Bayesian AB testing and credible intervals
+- **Multi-armed bandits**: Thompson sampling, UCB algorithms
+- **Advanced validation**: Custom validation rules, adaptive tolerances
+- **Enhanced scoring**: Weighted scoring, partial credit, learning analytics
+- **Advanced business impact**: ROI calculations, risk-adjusted revenue projections
+- **Multi-metric analysis**: CUPED, variance reduction, multiple outcome variables
 
 All extensions maintain the core principles of determinism, purity, and mathematical focus.
+
+## Recent Updates
+
+### Question 7 Implementation
+- **Added rollout decision question**: New Question 7 in analysis section
+- **`make_rollout_decision()` function**: CI-based go/no-go decision logic
+- **Updated validation**: Support for 7 analysis questions
+- **Enhanced scoring**: Rollout decision validation with exact match tolerance
+
+### Architecture Improvements
+- **Core validation module**: Centralized answer validation and scoring
+- **Core scoring module**: Answer key generation and quiz result management
+- **UI simplification**: Removed duplicated statistical calculations from UI layer
+- **Separation of concerns**: UI focuses on flow, core handles calculations
+
+### Function Status
+- **`calculate_business_impact()`**: Still functional, provides comprehensive business analysis
+- **`make_rollout_decision()`**: New focused function for CI-based decisions
+- **`_generate_recommendation()`**: Used internally by `analyze_results()`
+- **`assess_test_quality()`**: Available but not currently used in UI

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -15,6 +15,27 @@ from .types import (
     TestQuality,
 )
 
+from .validation import (
+    ValidationResult,
+    ScoringResult,
+    validate_design_answer,
+    validate_analysis_answer,
+    score_design_answers,
+    score_analysis_answers,
+)
+
+from .analyze import (
+    make_rollout_decision,
+)
+
+from .scoring import (
+    AnswerKey,
+    QuizResult,
+    generate_design_answer_key,
+    generate_analysis_answer_key,
+    create_complete_quiz_result,
+)
+
 __all__ = [
     "Allocation",
     "DesignParams", 
@@ -23,4 +44,16 @@ __all__ = [
     "AnalysisResult",
     "BusinessImpact",
     "TestQuality",
+    "ValidationResult",
+    "ScoringResult",
+    "validate_design_answer",
+    "validate_analysis_answer",
+    "score_design_answers",
+    "score_analysis_answers",
+    "make_rollout_decision",
+    "AnswerKey",
+    "QuizResult",
+    "generate_design_answer_key",
+    "generate_analysis_answer_key",
+    "create_complete_quiz_result",
 ]

--- a/core/analyze.py
+++ b/core/analyze.py
@@ -435,6 +435,36 @@ def _generate_recommendation(significant: bool, p_value: float,
             return "No significant difference detected. Consider alternative approaches or hypothesis refinement."
 
 
+def make_rollout_decision(
+    sim_result: SimResult, 
+    analysis_result: AnalysisResult,
+    business_target_absolute: float
+) -> str:
+    """
+    Make rollout decision based on confidence interval vs business target.
+    
+    Args:
+        sim_result: Simulation results with observed lift
+        analysis_result: Statistical analysis with CI bounds
+        business_target_absolute: Business's target absolute lift (e.g., 0.03 for 3%)
+        
+    Returns:
+        Decision: "proceed_with_confidence", "proceed_with_caution", "do_not_proceed"
+    """
+    ci_lower, ci_upper = analysis_result.confidence_interval
+    
+    # Check if business target is achievable within CI
+    if ci_upper < business_target_absolute:
+        # Upper bound is below target - target not achievable
+        return "do_not_proceed"
+    elif ci_lower >= business_target_absolute:
+        # Lower bound is above target - target is very likely achievable
+        return "proceed_with_confidence"
+    else:
+        # Target is within CI bounds - proceed with caution
+        return "proceed_with_caution"
+
+
 def calculate_business_impact(sim_result: SimResult, 
                             revenue_per_conversion: Optional[float] = None,
                             monthly_traffic: Optional[int] = None) -> BusinessImpact:

--- a/core/scoring.py
+++ b/core/scoring.py
@@ -1,0 +1,317 @@
+"""
+Scoring and answer key generation for AB test simulator.
+
+This module provides comprehensive scoring functions and answer key generation
+for both design and analysis questions.
+"""
+
+from typing import Dict, Any, List, Optional
+from dataclasses import dataclass
+
+from .types import SimResult, DesignParams
+from .validation import ValidationResult, ScoringResult, calculate_correct_design_answers, calculate_correct_analysis_answers
+
+
+@dataclass(frozen=True)
+class AnswerKey:
+    """Answer key for quiz questions."""
+    question_type: str  # "design" or "analysis"
+    questions: List[Dict[str, Any]]
+    correct_answers: Dict[str, Any]
+    max_score: int
+
+
+@dataclass(frozen=True)
+class QuizResult:
+    """Complete quiz result with scoring and feedback."""
+    answer_key: AnswerKey
+    scoring_result: ScoringResult
+    user_answers: Dict[str, Any]
+    feedback: List[str]
+
+
+def generate_design_answer_key(design_params: DesignParams, 
+                              sample_size_result: Any) -> AnswerKey:
+    """
+    Generate answer key for design questions.
+    
+    Args:
+        design_params: Design parameters from scenario
+        sample_size_result: Sample size calculation result
+        
+    Returns:
+        AnswerKey with all design questions and correct answers
+    """
+    questions = [
+        {
+            "number": 1,
+            "question": "What is the business's targeted minimum detectable effect (MDE) in absolute terms?",
+            "hint": "Look for the MDE value in the scenario description",
+            "type": "percentage_points"
+        },
+        {
+            "number": 2,
+            "question": "What is the target conversion rate for the treatment group?",
+            "hint": "Calculate: Baseline Rate + MDE",
+            "type": "percentage"
+        },
+        {
+            "number": 3,
+            "question": "What is the relative lift percentage?",
+            "hint": "Calculate: (MDE / Baseline Rate) × 100",
+            "type": "percentage"
+        },
+        {
+            "number": 4,
+            "question": "What is the required sample size per group?",
+            "hint": "Use the two-proportion z-test sample size formula",
+            "type": "integer"
+        },
+        {
+            "number": 5,
+            "question": "How many days will the experiment need to run?",
+            "hint": "Calculate: Total Sample Size ÷ Daily Traffic",
+            "type": "integer"
+        },
+        {
+            "number": 6,
+            "question": "How many additional conversions per day will the treatment generate?",
+            "hint": "Calculate: Daily Traffic × MDE",
+            "type": "integer"
+        }
+    ]
+    
+    correct_answers = calculate_correct_design_answers(design_params, sample_size_result)
+    
+    return AnswerKey(
+        question_type="design",
+        questions=questions,
+        correct_answers=correct_answers,
+        max_score=6
+    )
+
+
+def generate_analysis_answer_key(sim_result: SimResult) -> AnswerKey:
+    """
+    Generate answer key for analysis questions.
+    
+    Args:
+        sim_result: Simulation results
+        
+    Returns:
+        AnswerKey with all analysis questions and correct answers
+    """
+    questions = [
+        {
+            "number": 1,
+            "question": "What is the conversion rate for the control group?",
+            "hint": "Calculate: Control Conversions ÷ Control Users",
+            "type": "percentage"
+        },
+        {
+            "number": 2,
+            "question": "What is the conversion rate for the treatment group?",
+            "hint": "Calculate: Treatment Conversions ÷ Treatment Users",
+            "type": "percentage"
+        },
+        {
+            "number": 3,
+            "question": "What is the absolute lift between treatment and control?",
+            "hint": "Calculate: Treatment Rate - Control Rate",
+            "type": "percentage_points"
+        },
+        {
+            "number": 4,
+            "question": "What is the relative lift percentage?",
+            "hint": "Calculate: (Treatment Rate - Control Rate) ÷ Control Rate × 100",
+            "type": "percentage"
+        },
+        {
+            "number": 5,
+            "question": "What is the p-value for the difference between groups?",
+            "hint": "Perform a two-proportion z-test",
+            "type": "decimal"
+        },
+        {
+            "number": 6,
+            "question": "What is the 95% confidence interval for the difference?",
+            "hint": "Calculate confidence interval for difference in proportions",
+            "type": "interval"
+        }
+    ]
+    
+    correct_answers = calculate_correct_analysis_answers(sim_result)
+    
+    return AnswerKey(
+        question_type="analysis",
+        questions=questions,
+        correct_answers=correct_answers,
+        max_score=6
+    )
+
+
+def generate_quiz_feedback(scoring_result: ScoringResult, 
+                          answer_key: AnswerKey) -> List[str]:
+    """
+    Generate detailed feedback for quiz results.
+    
+    Args:
+        scoring_result: Scoring results
+        answer_key: Answer key with questions
+        
+    Returns:
+        List of feedback strings
+    """
+    feedback = []
+    
+    # Overall performance
+    feedback.append(f"Overall Score: {scoring_result.total_score}/{scoring_result.max_score} ({scoring_result.percentage:.1f}%)")
+    feedback.append(f"Grade: {scoring_result.grade}")
+    
+    # Detailed feedback for each question
+    for question in answer_key.questions:
+        question_num = question["number"]
+        question_key = _get_question_key(question_num, answer_key.question_type)
+        
+        if question_key in scoring_result.scores:
+            score_info = scoring_result.scores[question_key]
+            if score_info["correct"]:
+                feedback.append(f"✅ Question {question_num}: Correct! Your answer: {score_info['user']}")
+            else:
+                feedback.append(f"❌ Question {question_num}: Incorrect. Your answer: {score_info['user']}, Correct answer: {score_info['correct']}")
+        else:
+            feedback.append(f"⚠️ Question {question_num}: No answer provided")
+    
+    return feedback
+
+
+def _get_question_key(question_num: int, question_type: str) -> str:
+    """Get the key for a question number and type."""
+    if question_type == "design":
+        keys = ["mde_absolute", "target_conversion_rate", "relative_lift_pct", 
+                "sample_size", "duration", "additional_conversions"]
+    else:  # analysis
+        keys = ["control_conversion_rate", "treatment_conversion_rate", 
+                "absolute_lift", "relative_lift", "p_value", "confidence_interval"]
+    
+    if 1 <= question_num <= len(keys):
+        return keys[question_num - 1]
+    else:
+        raise ValueError(f"Invalid question number: {question_num}")
+
+
+def create_complete_quiz_result(user_answers: Dict[str, Any],
+                               design_params: Optional[DesignParams] = None,
+                               sample_size_result: Optional[Any] = None,
+                               sim_result: Optional[SimResult] = None) -> QuizResult:
+    """
+    Create a complete quiz result with scoring and feedback.
+    
+    Args:
+        user_answers: User's answers
+        design_params: Design parameters (for design questions)
+        sample_size_result: Sample size result (for design questions)
+        sim_result: Simulation results (for analysis questions)
+        
+    Returns:
+        Complete QuizResult with scoring and feedback
+    """
+    if design_params is not None and sample_size_result is not None:
+        # Design questions
+        answer_key = generate_design_answer_key(design_params, sample_size_result)
+        from .validation import score_design_answers
+        scoring_result = score_design_answers(user_answers, design_params, sample_size_result)
+    elif sim_result is not None:
+        # Analysis questions
+        answer_key = generate_analysis_answer_key(sim_result)
+        from .validation import score_analysis_answers
+        scoring_result = score_analysis_answers(user_answers, sim_result)
+    else:
+        raise ValueError("Must provide either design_params+sample_size_result or sim_result")
+    
+    feedback = generate_quiz_feedback(scoring_result, answer_key)
+    
+    return QuizResult(
+        answer_key=answer_key,
+        scoring_result=scoring_result,
+        user_answers=user_answers,
+        feedback=feedback
+    )
+
+
+def export_answer_key_to_csv(answer_key: AnswerKey, filename: str) -> None:
+    """
+    Export answer key to CSV file.
+    
+    Args:
+        answer_key: Answer key to export
+        filename: Output filename
+    """
+    import csv
+    
+    with open(filename, 'w', newline='') as csvfile:
+        fieldnames = ['question_number', 'question', 'hint', 'type', 'correct_answer']
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        
+        writer.writeheader()
+        for question in answer_key.questions:
+            question_key = _get_question_key(question["number"], answer_key.question_type)
+            correct_answer = answer_key.correct_answers.get(question_key, "N/A")
+            
+            writer.writerow({
+                'question_number': question["number"],
+                'question': question["question"],
+                'hint': question["hint"],
+                'type': question["type"],
+                'correct_answer': correct_answer
+            })
+
+
+def export_quiz_results_to_csv(quiz_result: QuizResult, filename: str) -> None:
+    """
+    Export quiz results to CSV file.
+    
+    Args:
+        quiz_result: Quiz result to export
+        filename: Output filename
+    """
+    import csv
+    
+    with open(filename, 'w', newline='') as csvfile:
+        fieldnames = ['question_number', 'question', 'user_answer', 'correct_answer', 'is_correct', 'tolerance']
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        
+        writer.writeheader()
+        for question in quiz_result.answer_key.questions:
+            question_key = _get_question_key(question["number"], quiz_result.answer_key.question_type)
+            
+            if question_key in quiz_result.scoring_result.scores:
+                score_info = quiz_result.scoring_result.scores[question_key]
+                user_answer = score_info["user"]
+                correct_answer = score_info["correct"]
+                is_correct = score_info["correct"]
+                tolerance = score_info.get("tolerance", "N/A")
+            else:
+                user_answer = "No answer"
+                correct_answer = quiz_result.answer_key.correct_answers.get(question_key, "N/A")
+                is_correct = False
+                tolerance = "N/A"
+            
+            writer.writerow({
+                'question_number': question["number"],
+                'question': question["question"],
+                'user_answer': user_answer,
+                'correct_answer': correct_answer,
+                'is_correct': is_correct,
+                'tolerance': tolerance
+            })
+        
+        # Add summary row
+        writer.writerow({
+            'question_number': 'SUMMARY',
+            'question': f'Total Score: {quiz_result.scoring_result.total_score}/{quiz_result.scoring_result.max_score} ({quiz_result.scoring_result.percentage:.1f}%)',
+            'user_answer': f'Grade: {quiz_result.scoring_result.grade}',
+            'correct_answer': 'N/A',
+            'is_correct': 'N/A',
+            'tolerance': 'N/A'
+        })

--- a/core/validation.py
+++ b/core/validation.py
@@ -1,0 +1,604 @@
+"""
+Validation and scoring logic for AB test simulator.
+
+This module provides validation and scoring functions for quiz answers,
+ensuring consistent logic across all UI components.
+"""
+
+from typing import Dict, Any, Optional, Tuple
+from dataclasses import dataclass
+
+from .types import SimResult, DesignParams
+from .design import compute_sample_size
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Result of answer validation."""
+    is_correct: bool
+    correct_answer: Any
+    feedback: str
+    tolerance: float
+
+
+@dataclass(frozen=True)
+class ScoringResult:
+    """Result of quiz scoring."""
+    scores: Dict[str, Dict[str, Any]]
+    total_score: int
+    max_score: int
+    percentage: float
+    grade: str
+
+
+def validate_design_answer(question_num: int, user_answer: float, 
+                          design_params: DesignParams, 
+                          sample_size_result: Optional[Any] = None,
+                          mde_absolute: Optional[float] = None) -> ValidationResult:
+    """
+    Validate a single design question answer.
+    
+    Args:
+        question_num: Question number (1-6)
+        user_answer: User's answer
+        design_params: Design parameters from scenario
+        sample_size_result: Sample size calculation result
+        
+    Returns:
+        ValidationResult with correctness and feedback
+    """
+    baseline = design_params.baseline_conversion_rate
+    target_lift = design_params.target_lift_pct
+    # Use provided mde_absolute or calculate as fallback
+    if mde_absolute is None:
+        mde_absolute = baseline * target_lift  # Fallback calculation
+    
+    if question_num == 1:
+        # Question 1: Business's targeted MDE
+        correct_answer = mde_absolute * 100  # Convert to percentage points
+        tolerance = 0.5  # 0.5 percentage points tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:.1f} percentage points"
+        
+    elif question_num == 2:
+        # Question 2: Target conversion rate calculation
+        correct_answer = (baseline + mde_absolute) * 100  # Convert to percentage
+        tolerance = 0.5  # 0.5% tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:.1f}%"
+        
+    elif question_num == 3:
+        # Question 3: Relative lift calculation from MDE
+        correct_answer = (mde_absolute / baseline) * 100  # Convert to relative lift percentage
+        tolerance = 2.0  # 2% tolerance for relative lift
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:.1f}%"
+        
+    elif question_num == 4:
+        # Question 4: Sample size calculation
+        if sample_size_result is None:
+            sample_size_result = compute_sample_size(design_params)
+        correct_answer = sample_size_result.per_arm
+        tolerance = 50  # 50 users tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:,} users per group"
+        
+    elif question_num == 5:
+        # Question 5: Duration calculation
+        if sample_size_result is None:
+            sample_size_result = compute_sample_size(design_params)
+        required_sample_size = sample_size_result.per_arm * 2  # Total sample size
+        correct_answer = max(1, round(required_sample_size / design_params.expected_daily_traffic))
+        tolerance = 1  # 1 day tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer} days"
+        
+    elif question_num == 6:
+        # Question 6: Additional conversions per day
+        correct_answer = round(design_params.expected_daily_traffic * mde_absolute)
+        tolerance = 5  # 5 conversions tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer} additional conversions per day"
+        
+    else:
+        raise ValueError(f"Invalid question number: {question_num}")
+    
+    return ValidationResult(
+        is_correct=is_correct,
+        correct_answer=correct_answer,
+        feedback=feedback,
+        tolerance=tolerance
+    )
+
+
+def validate_analysis_answer(question_num: int, user_answer: float, 
+                           sim_result: SimResult, business_target_absolute: float = None) -> ValidationResult:
+    """
+    Validate a single analysis question answer.
+    
+    Args:
+        question_num: Question number (1-7)
+        user_answer: User's answer
+        sim_result: Simulation results
+        business_target_absolute: Business target absolute lift for Question 7
+        
+    Returns:
+        ValidationResult with correctness and feedback
+    """
+    if question_num == 1:
+        # Question 1: Control conversion rate
+        correct_answer = sim_result.control_rate * 100  # Convert to percentage
+        tolerance = 0.05  # 0.05% tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:.3f}%"
+        
+    elif question_num == 2:
+        # Question 2: Treatment conversion rate
+        correct_answer = sim_result.treatment_rate * 100  # Convert to percentage
+        tolerance = 0.05  # 0.05% tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:.3f}%"
+        
+    elif question_num == 3:
+        # Question 3: Absolute lift
+        correct_answer = sim_result.absolute_lift * 100  # Convert to percentage points
+        tolerance = 0.01  # 0.01 percentage point tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:.3f} percentage points"
+        
+    elif question_num == 4:
+        # Question 4: Relative lift
+        correct_answer = sim_result.relative_lift_pct * 100  # Convert to percentage
+        tolerance = 0.5  # 0.5% tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:.1f}%"
+        
+    elif question_num == 5:
+        # Question 5: P-value
+        from .analyze import analyze_results
+        analysis = analyze_results(sim_result, alpha=0.05)
+        correct_answer = analysis.p_value
+        tolerance = 0.001  # 0.001 tolerance
+        is_correct = abs(user_answer - correct_answer) <= tolerance
+        feedback = f"Correct answer: {correct_answer:.3f}"
+        
+    elif question_num == 6:
+        # Question 6: Confidence interval
+        from .analyze import analyze_results
+        analysis = analyze_results(sim_result, alpha=0.05)
+        ci_lower, ci_upper = analysis.confidence_interval
+        correct_answer = (ci_lower * 100, ci_upper * 100)  # Convert to percentage points
+        tolerance = 0.01  # 0.01 percentage point tolerance
+        
+        # For confidence interval, we need to check if user provided both bounds
+        if isinstance(user_answer, tuple) and len(user_answer) == 2:
+            user_lower, user_upper = user_answer
+            is_correct = (abs(user_lower - correct_answer[0]) <= tolerance and 
+                         abs(user_upper - correct_answer[1]) <= tolerance)
+        else:
+            is_correct = False
+            
+        feedback = f"Correct answer: [{correct_answer[0]:.2f}%, {correct_answer[1]:.2f}%]"
+        
+    elif question_num == 7:
+        # Question 7: Rollout decision
+        if business_target_absolute is None:
+            raise ValueError("business_target_absolute is required for Question 7")
+        
+        from .analyze import analyze_results, make_rollout_decision
+        analysis = analyze_results(sim_result, alpha=0.05)
+        correct_answer = make_rollout_decision(sim_result, analysis, business_target_absolute)
+        tolerance = "exact_match"
+        is_correct = str(user_answer).lower() == correct_answer.lower()
+        feedback = f"Correct answer: {correct_answer}"
+        
+    else:
+        raise ValueError(f"Invalid question number: {question_num}")
+    
+    return ValidationResult(
+        is_correct=is_correct,
+        correct_answer=correct_answer,
+        feedback=feedback,
+        tolerance=tolerance
+    )
+
+
+def calculate_correct_design_answers(design_params: DesignParams, 
+                                   sample_size_result: Any,
+                                   mde_absolute: Optional[float] = None) -> Dict[str, Any]:
+    """
+    Calculate correct answers for all design questions.
+    
+    Args:
+        design_params: Design parameters from scenario
+        sample_size_result: Sample size calculation result
+        
+    Returns:
+        Dictionary with correct answers for all design questions
+    """
+    baseline = design_params.baseline_conversion_rate
+    target_lift = design_params.target_lift_pct
+    # Use provided mde_absolute or calculate as fallback
+    if mde_absolute is None:
+        mde_absolute = baseline * target_lift  # Fallback calculation
+    
+    # Calculate correct answers
+    correct_mde_absolute = mde_absolute * 100  # Convert to percentage points
+    correct_target_rate = (baseline + mde_absolute) * 100  # Convert to percentage
+    correct_relative_lift = (mde_absolute / baseline) * 100  # Convert to percentage
+    correct_sample_size = sample_size_result.per_arm
+    
+    # Calculate duration
+    required_sample_size = correct_sample_size * 2  # Total sample size
+    correct_duration = max(1, round(required_sample_size / design_params.expected_daily_traffic))
+    
+    # Calculate additional conversions per day
+    correct_additional_conversions = round(design_params.expected_daily_traffic * mde_absolute)
+    
+    return {
+        "mde_absolute": correct_mde_absolute,
+        "target_conversion_rate": correct_target_rate,
+        "relative_lift_pct": correct_relative_lift,
+        "sample_size": correct_sample_size,
+        "duration": correct_duration,
+        "additional_conversions": correct_additional_conversions
+    }
+
+
+def calculate_correct_analysis_answers(sim_result: SimResult, business_target_absolute: float = None) -> Dict[str, Any]:
+    """
+    Calculate correct answers for all analysis questions.
+    
+    Args:
+        sim_result: Simulation results
+        business_target_absolute: Business target absolute lift for rollout decision
+        
+    Returns:
+        Dictionary with correct answers for all analysis questions
+    """
+    from .analyze import analyze_results, make_rollout_decision
+    
+    # Run analysis to get p-value and confidence interval
+    analysis = analyze_results(sim_result, alpha=0.05)
+    
+    # Calculate correct answers
+    correct_control_rate = sim_result.control_rate * 100  # Convert to percentage
+    correct_treatment_rate = sim_result.treatment_rate * 100  # Convert to percentage
+    correct_absolute_lift = sim_result.absolute_lift * 100  # Convert to percentage points
+    correct_relative_lift = sim_result.relative_lift_pct * 100  # Convert to percentage
+    correct_p_value = analysis.p_value
+    correct_ci_lower, correct_ci_upper = analysis.confidence_interval
+    correct_ci = (correct_ci_lower * 100, correct_ci_upper * 100)  # Convert to percentage points
+    
+    # Calculate rollout decision if business target provided
+    correct_rollout_decision = None
+    if business_target_absolute is not None:
+        correct_rollout_decision = make_rollout_decision(sim_result, analysis, business_target_absolute)
+    
+    result = {
+        "control_conversion_rate": correct_control_rate,
+        "treatment_conversion_rate": correct_treatment_rate,
+        "absolute_lift": correct_absolute_lift,
+        "relative_lift": correct_relative_lift,
+        "p_value": correct_p_value,
+        "confidence_interval": correct_ci
+    }
+    
+    if correct_rollout_decision is not None:
+        result["rollout_decision"] = correct_rollout_decision
+    
+    return result
+
+
+def score_design_answers(user_answers: Dict[str, Any], 
+                        design_params: DesignParams,
+                        sample_size_result: Any,
+                        mde_absolute: Optional[float] = None) -> ScoringResult:
+    """
+    Score design question answers.
+    
+    Args:
+        user_answers: User's answers
+        design_params: Design parameters from scenario
+        sample_size_result: Sample size calculation result
+        
+    Returns:
+        ScoringResult with scores and feedback
+    """
+    # Calculate correct answers
+    correct_answers = calculate_correct_design_answers(design_params, sample_size_result, mde_absolute)
+    
+    # Score each answer
+    scores = {}
+    total_score = 0
+    max_score = 6
+    
+    # Question 1: MDE (absolute)
+    user_mde = user_answers.get("mde_absolute", 0)
+    correct_mde = correct_answers["mde_absolute"]
+    tolerance = 0.5
+    is_correct = abs(user_mde - correct_mde) <= tolerance
+    scores["mde_absolute"] = {
+        "correct": is_correct,
+        "user": user_mde,
+        "correct_answer": correct_mde,
+        "tolerance": tolerance
+    }
+    if is_correct:
+        total_score += 1
+    
+    # Question 2: Target conversion rate
+    user_target = user_answers.get("target_conversion_rate", 0)
+    correct_target = correct_answers["target_conversion_rate"]
+    tolerance = 0.5
+    is_correct = abs(user_target - correct_target) <= tolerance
+    scores["target_conversion_rate"] = {
+        "correct": is_correct,
+        "user": user_target,
+        "correct_answer": correct_target,
+        "tolerance": tolerance
+    }
+    if is_correct:
+        total_score += 1
+    
+    # Question 3: Relative lift
+    user_relative = user_answers.get("relative_lift_pct", 0)
+    correct_relative = correct_answers["relative_lift_pct"]
+    tolerance = 2.0
+    is_correct = abs(user_relative - correct_relative) <= tolerance
+    scores["relative_lift_pct"] = {
+        "correct": is_correct,
+        "user": user_relative,
+        "correct_answer": correct_relative,
+        "tolerance": tolerance
+    }
+    if is_correct:
+        total_score += 1
+    
+    # Question 4: Sample size
+    user_sample = user_answers.get("sample_size", 0)
+    correct_sample = correct_answers["sample_size"]
+    tolerance = 50
+    is_correct = abs(user_sample - correct_sample) <= tolerance
+    scores["sample_size"] = {
+        "correct": is_correct,
+        "user": user_sample,
+        "correct_answer": correct_sample,
+        "tolerance": tolerance
+    }
+    if is_correct:
+        total_score += 1
+    
+    # Question 5: Duration
+    user_duration = user_answers.get("duration", 0)
+    correct_duration = correct_answers["duration"]
+    tolerance = 1
+    is_correct = abs(user_duration - correct_duration) <= tolerance
+    scores["duration"] = {
+        "correct": is_correct,
+        "user": user_duration,
+        "correct_answer": correct_duration,
+        "tolerance": tolerance
+    }
+    if is_correct:
+        total_score += 1
+    
+    # Question 6: Additional conversions
+    user_conversions = user_answers.get("additional_conversions", 0)
+    correct_conversions = correct_answers["additional_conversions"]
+    tolerance = 5
+    is_correct = abs(user_conversions - correct_conversions) <= tolerance
+    scores["additional_conversions"] = {
+        "correct": is_correct,
+        "user": user_conversions,
+        "correct_answer": correct_conversions,
+        "tolerance": tolerance
+    }
+    if is_correct:
+        total_score += 1
+    
+    # Calculate percentage and grade
+    percentage = (total_score / max_score) * 100 if max_score > 0 else 0
+    grade = "A" if percentage >= 90 else "B" if percentage >= 80 else "C" if percentage >= 70 else "D" if percentage >= 60 else "F"
+    
+    return ScoringResult(
+        scores=scores,
+        total_score=total_score,
+        max_score=max_score,
+        percentage=percentage,
+        grade=grade
+    )
+
+
+def score_analysis_answers(user_answers: Dict[str, Any], 
+                          sim_result: SimResult,
+                          business_target_absolute: float = None) -> ScoringResult:
+    """
+    Score analysis question answers.
+    
+    Args:
+        user_answers: User's answers
+        sim_result: Simulation results
+        business_target_absolute: Business target absolute lift for rollout decision
+        
+    Returns:
+        ScoringResult with scores and feedback
+    """
+    # Calculate correct answers
+    correct_answers = calculate_correct_analysis_answers(sim_result, business_target_absolute)
+    
+    # Score each answer
+    scores = {}
+    total_score = 0
+    max_score = 6
+    
+    # Question 1: Control conversion rate
+    user_control = user_answers.get("control_conversion_rate")
+    if user_control is not None:
+        correct_control = correct_answers["control_conversion_rate"]
+        tolerance = 0.05
+        is_correct = abs(user_control - correct_control) <= tolerance
+        scores["control_conversion_rate"] = {
+            "correct": is_correct,
+            "user": user_control,
+            "correct_answer": correct_control,
+            "tolerance": tolerance
+        }
+        if is_correct:
+            total_score += 1
+    else:
+        scores["control_conversion_rate"] = {
+            "correct": False,
+            "user": "No answer",
+            "correct_answer": correct_answers["control_conversion_rate"],
+            "tolerance": 0.05
+        }
+    
+    # Question 2: Treatment conversion rate
+    user_treatment = user_answers.get("treatment_conversion_rate")
+    if user_treatment is not None:
+        correct_treatment = correct_answers["treatment_conversion_rate"]
+        tolerance = 0.05
+        is_correct = abs(user_treatment - correct_treatment) <= tolerance
+        scores["treatment_conversion_rate"] = {
+            "correct": is_correct,
+            "user": user_treatment,
+            "correct_answer": correct_treatment,
+            "tolerance": tolerance
+        }
+        if is_correct:
+            total_score += 1
+    else:
+        scores["treatment_conversion_rate"] = {
+            "correct": False,
+            "user": "No answer",
+            "correct_answer": correct_answers["treatment_conversion_rate"],
+            "tolerance": 0.05
+        }
+    
+    # Question 3: Absolute lift
+    user_absolute = user_answers.get("absolute_lift")
+    if user_absolute is not None:
+        correct_absolute = correct_answers["absolute_lift"]
+        tolerance = 0.01
+        is_correct = abs(user_absolute - correct_absolute) <= tolerance
+        scores["absolute_lift"] = {
+            "correct": is_correct,
+            "user": user_absolute,
+            "correct_answer": correct_absolute,
+            "tolerance": tolerance
+        }
+        if is_correct:
+            total_score += 1
+    else:
+        scores["absolute_lift"] = {
+            "correct": False,
+            "user": "No answer",
+            "correct_answer": correct_answers["absolute_lift"],
+            "tolerance": 0.01
+        }
+    
+    # Question 4: Relative lift
+    user_relative = user_answers.get("relative_lift")
+    if user_relative is not None:
+        correct_relative = correct_answers["relative_lift"]
+        tolerance = 0.5
+        is_correct = abs(user_relative - correct_relative) <= tolerance
+        scores["relative_lift"] = {
+            "correct": is_correct,
+            "user": user_relative,
+            "correct_answer": correct_relative,
+            "tolerance": tolerance
+        }
+        if is_correct:
+            total_score += 1
+    else:
+        scores["relative_lift"] = {
+            "correct": False,
+            "user": "No answer",
+            "correct_answer": correct_answers["relative_lift"],
+            "tolerance": 0.5
+        }
+    
+    # Question 5: P-value
+    user_p_value = user_answers.get("p_value")
+    if user_p_value is not None:
+        correct_p_value = correct_answers["p_value"]
+        tolerance = 0.001
+        is_correct = abs(user_p_value - correct_p_value) <= tolerance
+        scores["p_value"] = {
+            "correct": is_correct,
+            "user": user_p_value,
+            "correct_answer": correct_p_value,
+            "tolerance": tolerance
+        }
+        if is_correct:
+            total_score += 1
+    else:
+        scores["p_value"] = {
+            "correct": False,
+            "user": "No answer",
+            "correct_answer": correct_answers["p_value"],
+            "tolerance": 0.001
+        }
+    
+    # Question 6: Confidence interval
+    user_ci = user_answers.get("confidence_interval")
+    if user_ci is not None:
+        correct_ci = correct_answers["confidence_interval"]
+        tolerance = 0.01
+        if isinstance(user_ci, tuple) and len(user_ci) == 2:
+            user_lower, user_upper = user_ci
+            is_correct = (abs(user_lower - correct_ci[0]) <= tolerance and 
+                         abs(user_upper - correct_ci[1]) <= tolerance)
+        else:
+            is_correct = False
+        scores["confidence_interval"] = {
+            "correct": is_correct,
+            "user": f"[{user_ci[0]:.2f}%, {user_ci[1]:.2f}%]" if isinstance(user_ci, tuple) else str(user_ci),
+            "correct_answer": f"[{correct_ci[0]:.2f}%, {correct_ci[1]:.2f}%]",
+            "tolerance": tolerance
+        }
+        if is_correct:
+            total_score += 1
+    else:
+        scores["confidence_interval"] = {
+            "correct": False,
+            "user": "No answer",
+            "correct_answer": f"[{correct_answers['confidence_interval'][0]:.2f}%, {correct_answers['confidence_interval'][1]:.2f}%]",
+            "tolerance": 0.01
+        }
+    
+    # Question 7: Rollout decision
+    user_decision = user_answers.get("rollout_decision")
+    if user_decision is not None:
+        correct_decision = correct_answers["rollout_decision"]
+        is_correct = user_decision.lower() == correct_decision.lower()
+        scores["rollout_decision"] = {
+            "correct": is_correct,
+            "user": user_decision,
+            "correct_answer": correct_decision,
+            "tolerance": "exact_match"
+        }
+        if is_correct:
+            total_score += 1
+    else:
+        scores["rollout_decision"] = {
+            "correct": False,
+            "user": "No answer",
+            "correct_answer": correct_answers["rollout_decision"],
+            "tolerance": "exact_match"
+        }
+    
+    # Calculate percentage and grade
+    max_score = 7  # Updated for 7 questions
+    percentage = (total_score / max_score) * 100 if max_score > 0 else 0
+    grade = "A" if percentage >= 90 else "B" if percentage >= 80 else "C" if percentage >= 70 else "D" if percentage >= 60 else "F"
+    
+    return ScoringResult(
+        scores=scores,
+        total_score=total_score,
+        max_score=max_score,
+        percentage=percentage,
+        grade=grade
+    )

--- a/notebooks/ab_experimental_analysis_template.ipynb
+++ b/notebooks/ab_experimental_analysis_template.ipynb
@@ -1,0 +1,359 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# A/B Test Experimental Analysis Framework\n",
+        "\n",
+        "This notebook provides a framework for analyzing experimental data from your A/B test.\n",
+        "Use this template alongside the downloaded CSV data to work through the analysis questions.\n",
+        "\n",
+        "## Setup and Data Import\n",
+        "First, let's import the necessary libraries and load the experimental data.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Import necessary libraries\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "import seaborn as sns\n",
+        "from scipy import stats\n",
+        "\n",
+        "# Set display options\n",
+        "pd.set_option('display.max_columns', None)\n",
+        "pd.set_option('display.width', None)\n",
+        "\n",
+        "print(\"Libraries imported successfully!\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Load the experimental data\n",
+        "# Replace 'experiment_data.csv' with the actual filename you downloaded\n",
+        "df = pd.read_csv('experiment_data.csv')\n",
+        "\n",
+        "print(f\"Data loaded successfully!\")\n",
+        "print(f\"Dataset shape: {df.shape}\")\n",
+        "print(f\"\\nColumn names: {list(df.columns)}\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Explore the data structure\n",
+        "print(\"First 5 rows:\")\n",
+        "print(df.head())\n",
+        "\n",
+        "print(\"\\nData types:\")\n",
+        "print(df.dtypes)\n",
+        "\n",
+        "print(\"\\nBasic statistics:\")\n",
+        "print(df.describe())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Data Overview\n",
+        "Let's examine the experimental groups and overall conversion patterns.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Check the distribution of users across groups\n",
+        "print(\"Group distribution:\")\n",
+        "print(df['group'].value_counts())\n",
+        "\n",
+        "print(\"\\nConversion distribution:\")\n",
+        "print(df['converted'].value_counts())\n",
+        "\n",
+        "print(\"\\nConversion by group:\")\n",
+        "print(pd.crosstab(df['group'], df['converted'], margins=True))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Question 1: Control Group Conversion Rate\n",
+        "\n",
+        "Calculate the conversion rate for the control group.\n",
+        "**Formula**: Conversions ÷ Total Users in Control Group\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Filter control group data\n",
+        "control_data = df[df['group'] == 'control']\n",
+        "\n",
+        "# Calculate control group metrics\n",
+        "control_total_users = len(control_data)  # Total users in control group\n",
+        "control_conversions = control_data['converted'].sum()  # Number of conversions in control group\n",
+        "control_conversion_rate = control_conversions / control_total_users  # Calculate: conversions / total_users\n",
+        "\n",
+        "print(f\"Control Group Analysis:\")\n",
+        "print(f\"Total users: {control_total_users:,}\")\n",
+        "print(f\"Conversions: {control_conversions:,}\")\n",
+        "print(f\"Conversion rate: {control_conversion_rate:.3%}\")\n",
+        "print(f\"Conversion rate (as percentage): {control_conversion_rate * 100:.3f}%\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Question 2: Treatment Group Conversion Rate\n",
+        "\n",
+        "Calculate the conversion rate for the treatment group.\n",
+        "**Formula**: Conversions ÷ Total Users in Treatment Group\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Filter treatment group data\n",
+        "treatment_data = df[df['group'] == 'treatment']\n",
+        "\n",
+        "# Calculate treatment group metrics\n",
+        "treatment_total_users = len(treatment_data)  # Total users in treatment group\n",
+        "treatment_conversions = treatment_data['converted'].sum()  # Number of conversions in treatment group\n",
+        "treatment_conversion_rate = treatment_conversions / treatment_total_users  # Calculate: conversions / total_users\n",
+        "\n",
+        "print(f\"Treatment Group Analysis:\")\n",
+        "print(f\"Total users: {treatment_total_users:,}\")\n",
+        "print(f\"Conversions: {treatment_conversions:,}\")\n",
+        "print(f\"Conversion rate: {treatment_conversion_rate:.3%}\")\n",
+        "print(f\"Conversion rate (as percentage): {treatment_conversion_rate * 100:.3f}%\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Question 3: Absolute Lift\n",
+        "\n",
+        "Calculate the absolute lift between treatment and control groups.\n",
+        "**Formula**: Treatment Rate - Control Rate (in percentage points)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Calculate the absolute lift\n",
+        "absolute_lift = treatment_conversion_rate - control_conversion_rate  # Calculate: treatment_rate - control_rate\n",
+        "\n",
+        "print(f\"Absolute Lift Analysis:\")\n",
+        "print(f\"Treatment rate: {treatment_conversion_rate:.3%}\")\n",
+        "print(f\"Control rate: {control_conversion_rate:.3%}\")\n",
+        "print(f\"Absolute lift: {absolute_lift:.3f}\")\n",
+        "print(f\"Absolute lift (as percentage): {absolute_lift * 100:.3f} percentage points\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Question 4: Relative Lift\n",
+        "\n",
+        "Calculate the relative lift between treatment and control groups.\n",
+        "**Formula**: (Treatment Rate - Control Rate) ÷ Control Rate × 100\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Calculate the relative lift\n",
+        "relative_lift = (treatment_conversion_rate - control_conversion_rate) / control_conversion_rate * 100  # Calculate: (treatment_rate - control_rate) / control_rate * 100\n",
+        "\n",
+        "print(f\"Relative Lift Analysis:\")\n",
+        "print(f\"Treatment rate: {treatment_conversion_rate:.3%}\")\n",
+        "print(f\"Control rate: {control_conversion_rate:.3%}\")\n",
+        "print(f\"Relative lift: {relative_lift:.1f}%\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Question 5: Statistical Significance (P-value)\n",
+        "\n",
+        "Perform a two-proportion z-test to determine if the difference is statistically significant.\n",
+        "**Formula**: Two-proportion z-test p-value\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Perform two-proportion z-test\n",
+        "from statsmodels.stats.proportion import proportions_ztest\n",
+        "import numpy as np\n",
+        "\n",
+        "# Prepare data for the test\n",
+        "successes = np.array([treatment_conversions, control_conversions])\n",
+        "samples = np.array([treatment_total_users, control_total_users])\n",
+        "\n",
+        "# Perform the test\n",
+        "z_stat, p_value = proportions_ztest(successes, samples)\n",
+        "\n",
+        "print(f\"Statistical Significance Analysis:\")\n",
+        "print(f\"Z-statistic: {z_stat:.4f}\")\n",
+        "print(f\"P-value: {p_value:.6f}\")\n",
+        "print(f\"Significant at α=0.05? {'Yes' if p_value < 0.05 else 'No'}\")\n",
+        "print(f\"Significant at α=0.01? {'Yes' if p_value < 0.01 else 'No'}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Question 6: Confidence Interval for Difference\n",
+        "\n",
+        "Calculate the 95% confidence interval for the difference between treatment and control groups.\n",
+        "**Formula**: (p1 - p2) ± z_α/2 × SE(p1 - p2)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Question 7: Rollout Decision\n",
+        "# Based on confidence interval and business target\n",
+        "\n",
+        "# Business target (from experiment design)\n",
+        "business_target_absolute = None  # Fill in: Business target absolute lift (e.g., 0.03 for 3%)\n",
+        "business_target_relative = None  # Fill in: Business target relative lift (e.g., 0.20 for 20%)\n",
+        "\n",
+        "# Decision logic\n",
+        "ci_lower, ci_upper = None, None  # Use your CI from Question 6\n",
+        "\n",
+        "if ci_lower is not None and ci_upper is not None and business_target_absolute is not None:\n",
+        "    if ci_upper < business_target_absolute:\n",
+        "        rollout_decision = \"do_not_proceed\"\n",
+        "        reasoning = \"Upper bound is below business target - target not achievable\"\n",
+        "    elif ci_lower >= business_target_absolute:\n",
+        "        rollout_decision = \"proceed_with_confidence\"\n",
+        "        reasoning = \"Lower bound is above business target - target very likely achievable\"\n",
+        "    else:\n",
+        "        rollout_decision = \"proceed_with_caution\"\n",
+        "        reasoning = \"Target is within CI bounds - proceed with caution\"\n",
+        "else:\n",
+        "    rollout_decision = \"need_more_data\"\n",
+        "    reasoning = \"Insufficient data for decision\"\n",
+        "\n",
+        "print(f\"Rollout Decision: {rollout_decision}\")\n",
+        "print(f\"Reasoning: {reasoning}\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Calculate 95% confidence interval for the difference\n",
+        "p1, p2 = treatment_conversion_rate, control_conversion_rate\n",
+        "n1, n2 = treatment_total_users, control_total_users\n",
+        "\n",
+        "# Standard error of difference\n",
+        "se_diff = np.sqrt(p1 * (1 - p1) / n1 + p2 * (1 - p2) / n2)\n",
+        "\n",
+        "# 95% CI for difference (z_0.025 = 1.96)\n",
+        "diff = p1 - p2\n",
+        "margin_error = 1.96 * se_diff\n",
+        "ci_lower = (diff - margin_error) * 100  # Convert to percentage\n",
+        "ci_upper = (diff + margin_error) * 100  # Convert to percentage\n",
+        "\n",
+        "print(f\"Confidence Interval Analysis:\")\n",
+        "print(f\"Difference: {diff:.3%}\")\n",
+        "print(f\"Standard Error: {se_diff:.6f}\")\n",
+        "print(f\"Margin of Error: {margin_error * 100:.2f} percentage points\")\n",
+        "print(f\"95% CI: [{ci_lower:.2f}%, {ci_upper:.2f}%]\")\n",
+        "print(f\"CI includes zero? {'Yes' if ci_lower <= 0 <= ci_upper else 'No'}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Final Summary\n",
+        "\n",
+        "Your complete experimental analysis results:\n",
+        "\n",
+        "### Key Metrics\n",
+        "- **Control conversion rate**: [Your answer]%\n",
+        "- **Treatment conversion rate**: [Your answer]%\n",
+        "- **Absolute lift**: [Your calculation] percentage points\n",
+        "- **Relative lift**: [Your calculation]%\n",
+        "\n",
+        "### Statistical Analysis\n",
+        "- **P-value**: [Your result]\n",
+        "- **95% Confidence Interval**: [Your result]%\n",
+        "- **Statistically significant**: [Yes/No]\n",
+        "\n",
+        "### Business Decision\n",
+        "- **Business target lift**: [Your calculation]%\n",
+        "- **Rollout recommendation**: [proceed_with_confidence/proceed_with_caution/do_not_proceed]\n",
+        "- **Reasoning**: [Your explanation based on CI vs target]\n",
+        "\n",
+        "### Sample Sizes\n",
+        "- **Control group**: [Your answer] users\n",
+        "- **Treatment group**: [Your answer] users\n",
+        "- **Total experiment size**: [Your calculation] users\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Resources\n",
+        "- [Two-proportion z-test explanation](https://stattrek.com/hypothesis-test/difference-in-proportions)\n",
+        "- [Statistical significance calculator](https://www.evanmiller.org/ab-testing/chi-squared.html)\n",
+        "- [Effect size interpretation](https://en.wikipedia.org/wiki/Effect_size)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
- Add Question 7 for interpreting confidence intervals vs business targets
- Implement make_rollout_decision() with CI-based go/no-go logic
- Create core validation and scoring modules for centralized logic
- Rebuild analysis section with 7 progressive questions
- Move statistical calculations from UI to core modules
- Fix p-value validation bug with duplicate dictionary keys
- Update analysis notebook template with Question 7
- Enhance separation of concerns with llm -> core -> ui architecture
- Improve user experience with consistent question flow
- Update comprehensive documentation and examples